### PR TITLE
Fix #input_placement_checker rb:49

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -46,7 +46,7 @@ class Game
     user_placement = user_placement.split
     all_coordinate_valid = user_placement.all? { |coordinate| @user_board.valid_coordinate?(coordinate) }
 
-    if user_placement_index && @user_board.valid_placement?(ship, user_placement) && all_coordinate_valid
+    if user_placement_index && all_coordinate_valid && @user_board.valid_placement?(ship, user_placement)
       @user_board.place(ship, user_placement)
       # Logic for sub placement check
       @user_board.cells.each do |coordinate, cell|


### PR DESCRIPTION
This branch will fixes a small issue in #input_placement_checker in game. This was caused bu inputs like 'a1 2a2 3' which caused a no method error on the #valid_placement? call on line 49. 